### PR TITLE
Handle an edge case when requested region is not in fragment file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Signac
 Title: Analysis of Single-Cell Chromatin Data
-Version: 1.9.0
-Date: 2022-12-07
+Version: 1.9.0.9000
+Date: 2023-03-02
 Authors@R: c(
   person(given = 'Tim', family = 'Stuart', email = 'tstuart@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-3044-0897')),
   person(given = 'Avi', family = 'Srivastava', email = 'asrivastava@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9798-2079')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Bug fixes:
+
+* Fixed error in `GetReadsInRegion()` when no fragments present that overlap the region (@rockweiler; [#1348](https://github.com/stuart-lab/signac/pull/1348))
+
 # Signac 1.9.0
 
 Bug fixes:

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1319,25 +1319,36 @@ GetReadsInRegion <- function(
     x = seqlevels(x = region),
     y = seqnamesTabix(file = tabix.file)
   )
-  region <- keepSeqlevels(
-    x = region,
-    value = common.seqlevels,
-    pruning.mode = "coarse"
-  )
-  reads <- scanTabix(file = tabix.file, param = region)
-  reads <- TabixOutputToDataFrame(reads = reads)
-  reads <- reads[
-    fmatch(x = reads$cell, table = cellmap, nomatch = 0L) > 0,
-  ]
-  # convert cell names to match names in object
-  reads$cell <- file.to.object[reads$cell]
-  if (!is.null(x = cells)) {
-    reads <- reads[reads$cell %in% cells, ]
+  if (length(common.seqlevels) != 0) {
+    region <- keepSeqlevels(
+      x = region,
+      value = common.seqlevels,
+      pruning.mode = "coarse"
+    )
+    reads <- scanTabix(file = tabix.file, param = region)
+    reads <- TabixOutputToDataFrame(reads = reads)
+    reads <- reads[
+      fmatch(x = reads$cell, table = cellmap, nomatch = 0L) > 0,
+    ]
+    # convert cell names to match names in object
+    reads$cell <- file.to.object[reads$cell]
+    if (!is.null(x = cells)) {
+      reads <- reads[reads$cell %in% cells, ]
+    }
+    if (nrow(reads) == 0) {
+      return(reads)
+    }
+    reads$length <- reads$end - reads$start
+  } else {
+    reads <- data.frame(
+      "chr" = "",
+      "start" = "",
+      "end" = "",
+      "cell" = "",
+      "count" = ""
+    )
+    reads <- reads[-1, ]
   }
-  if (nrow(reads) == 0) {
-    return(reads)
-  }
-  reads$length <- reads$end - reads$start
   return(reads)
 }
 
@@ -1794,8 +1805,9 @@ TabixOutputToDataFrame <- function(reads, record.ident = TRUE) {
   if (record.ident) {
     nrep <- elementNROWS(x = reads)
   }
+  original_names = names(reads)
   reads <- unlist(x = reads, use.names = FALSE)
-  if (length(x = reads) == 0) {
+  if (length(x = reads) == 0 | is.na(original_names)) {
     df <- data.frame(
       "chr" = "",
       "start" = "",


### PR DESCRIPTION
- Motivation
  - When GetReadsInRegion is called, if there are no fragments that overlap the region, for some reason Rsamtools::scanTabix is reporting all fragments if there is no overlap.  The catch is that it returns a named list with a 'region' called NA and lists all fragments in the file.  Therefore, when TabixOutputToDataFrame slurps up the overlapping fragments, it incorrectly thinks this named list element is a real overlapping region.

 - Solution
   - Within GetReadsInRegion, don't bother scanning the the tabix and converting the output with TabixOutputToDataFrame if there are no contigs in common.  Return a dataframe with no entries.
   - Within TabixOutputToDataFrame, correctly check if there really are no overlaps.  If there are no overlaps, return an empty reads dataframe.