### PR TITLE
Changing back to [[]] for feature-level metadata

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -303,11 +303,7 @@ FindTopFeatures.Assay <- function(
     verbose = verbose,
     ...
   )
-  if (packageVersion(pkg = "SeuratObject") < "4.9.9") {
-    object[[names(x = hvf.info)]] <- hvf.info
-  } else {
-    object[names(x = hvf.info)] <- hvf.info
-  }
+  object[[names(x = hvf.info)]] <- hvf.info
   if (is.null(x = min.cutoff)) {
     VariableFeatures(object = object) <- rownames(x = hvf.info)
   } else if (is.numeric(x = min.cutoff)) {


### PR DESCRIPTION
SeuratObject is going back to using the double bracket `[[]]` for feature-level metadata and using single brackets `[]` for accessing layer data. This switch caused the below code to fail.
```
> pbmc.atac <- LoadData("pbmcMultiome", "pbmc.atac")
> pbmc.atac <- subset(pbmc.atac, seurat_annotations != 'filtered')
Error in `LayerData<-`(object = `*tmp*`, layer = i, ..., value = value) : 
  'value' must be a 'matrix' or 'dgCMatrix' in v3 Assays, not a 'data.frame'
```
 I just removed the specific check for SeuratObject version as now the previous code will work normally. 
 