### PR TITLE
fix cases when regions are absent from motif.matrix

### DIFF
--- a/R/motifs.R
+++ b/R/motifs.R
@@ -192,11 +192,14 @@ RunChromVAR.ChromatinAssay <- function(
     warning("Count matrix contains non-integer values.
             ChromVAR should only be run on integer counts.")
   }
-  idx.keep <- rowSums(x = peak.matrix) > 0
-  peak.matrix <- peak.matrix[idx.keep, , drop = FALSE]
-  motif.matrix <- motif.matrix[idx.keep, , drop = FALSE]
+  regions.keep <- intersect(
+    rownames(peak.matrix)[rowSums(x = peak.matrix) > 0],
+    rownames(motif.matrix)
+  )
+  peak.matrix <- peak.matrix[regions.keep, , drop = FALSE]
+  motif.matrix <- motif.matrix[regions.keep, , drop = FALSE]
   peak.ranges <- granges(x = object)
-  peak.ranges <- peak.ranges[idx.keep]
+  peak.ranges <- peak.ranges[match(regions.keep, rownames(object))]
   chromvar.obj <- SummarizedExperiment::SummarizedExperiment(
     assays = list(counts = peak.matrix),
     rowRanges = peak.ranges


### PR DESCRIPTION
Hi,
I tried to run `RunChromVAR` and I got:
```
Error in .subscript.2ary(x, i, , drop = drop) : 
  logical subscript too long
```
I realized it was because the motif matrix was smaller than the peak matrix (some peaks have no motif).

I propose here a bug fix.