### PR TITLE
Fix error in using own motif database

### DIFF
--- a/R/motifs.R
+++ b/R/motifs.R
@@ -373,8 +373,8 @@ FindMotifs <- function(
   motif.names <- GetMotifData(
     object = object, assay = assay, slot = "motif.names"
   )
-  query.motifs <- motif.all[features, , drop = FALSE]
-  background.motifs <- motif.all[background, , drop = FALSE]
+  query.motifs <- motif.all[which(rownames(motif.all) %in% features), , drop = FALSE]
+  background.motifs <- motif.all[which(rownames(motif.all) %in% background), , drop = FALSE]
   query.counts <- colSums(x = query.motifs)
   background.counts <- colSums(x = background.motifs)
   percent.observed <- query.counts / length(x = features) * 100


### PR DESCRIPTION
When using my custom PWM motif database, run FindMotifs will error with
 `
Error in motif.all[features, , drop = FALSE] :
  object of type 'S4' is not subsettable`

![image](https://github.com/user-attachments/assets/d562a5f1-971f-4a6b-9e2c-cd0c17b3ce4c)

Using the peak index to replace the peak name will be more robust 