### PR TITLE
Fix:RegionPlot-bin-fix

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1001,9 +1001,11 @@ RegionPlot <- function(
           )
         )
       }
-      # fix bin label
-      df$bin <- (df$bin - (upstream/window)) * window
     }
+    
+    # fix bin label
+    df$bin <- (df$bin - (upstream/window)) * window
+
     df$assay <- assay[[j]]
     all.assay <- rbind(all.assay, df)
   }


### PR DESCRIPTION
great tools!
just found out a tiny mistake of `RegionPlot`
the original fix bin label process were inside the loop of dataframe rbind, which mess up the fix bin result.
just put the process after finishing dateframe rbind, works for me.

