### PR TITLE
Add back to line in group

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -169,6 +169,9 @@ SEXP groupCommand(
     line_seq.clear();
   } while(gzgets(fileHandler, buffer, buffer_length) !=0 );
 
+  // Back to line
+  Rcpp::Rcerr << "\n" << std::flush;
+
   //Cleanup
   gzclose(fileHandler);
 


### PR DESCRIPTION
Hi,
I noticed that there were a back to line missing in `CountFragments`.
For example when running in a for loop for multiple fragment files:
```
Found 2393 cell barcodes
Done Processing 70 million linesFound 5448 cell barcodes
Done Processing 60 million linesFound 38519 cell barcodes
Done Processing 11 million linesFound 4242 cell barcodes
...
```
I just added it.

Also I am not sure this bloc is useful:
https://github.com/stuart-lab/signac/blob/2984cd24f41aaad893903ff0aead5cd6af09e512/src/group.cpp#L157-L159